### PR TITLE
Remove cruft from IOC Makefile.<arch>

### DIFF
--- a/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/Makefile.darwin
+++ b/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/Makefile.darwin
@@ -1,12 +1,5 @@
 TOP = ../..
 include $(TOP)/configure/CONFIG
-#ARCH = win32-x86
-ARCH = darwin-x86
-TARGETS = envPaths
-include $(TOP)/configure/RULES.ioc
-TOP = ../..
-include $(TOP)/configure/CONFIG
-#ARCH = win32-x86
 ARCH = darwin-x86
 TARGETS = envPaths
 include $(TOP)/configure/RULES.ioc

--- a/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/Makefile.linux
+++ b/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/Makefile.linux
@@ -1,6 +1,5 @@
 TOP = ../..
 include $(TOP)/configure/CONFIG
-#ARCH = windows-x64
 ARCH = linux-x86_64
 TARGETS = envPaths
 include $(TOP)/configure/RULES.ioc


### PR DESCRIPTION
Remove unneeded commented out ARCH assignment, and remove duplicate
Makefile.darwin content.