### PR TITLE
Clean up st.cmd*

### DIFF
--- a/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/st.cmd
+++ b/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/st.cmd
@@ -1,4 +1,4 @@
-# Must have loaded envPaths via st.cmd.linux or st.cmd.win32
+# Must have loaded envPaths via st.cmd.*
 
 errlogInit(20000)
 

--- a/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/st.cmd.darwin
+++ b/iocs/NDDriverStdArraysIOC/iocBoot/iocNDDriverStdArrays/st.cmd.darwin
@@ -1,4 +1,3 @@
-epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 < envPaths.darwin
 < st.cmd
 


### PR DESCRIPTION
Generalize references to st.cmd.linux and st.cmd.win32 (which should
have been st.cmd.windows) as "st.cmd.*".

Do not set EPICS_CA_MAX_ARRAY_BYTES in st.cmd.darwin.  That environment
variable is not set in st.cmd.windows or st.cmd.linux, so it should not
be set in st.cmd.darwin either.  The system administrator or user should
set it appropriately elsewhere.