### PR TITLE
base frame timestamp off epicsTS

### DIFF
--- a/NDDriverStdArraysApp/src/NDDriverStdArrays.cpp
+++ b/NDDriverStdArraysApp/src/NDDriverStdArrays.cpp
@@ -320,8 +320,7 @@ void NDDriverStdArrays::doCallbacks()
 
     /* Put the frame number and timestamp into the NDArray */
     pArray->uniqueId = imageCounter;
-    updateTimeStamp(&pArray->epicsTS);
-    pArray->timeStamp = pArray->epicsTS.secPastEpoch + pArray->epicsTS.nsec/1.e9;
+    updateTimeStamps(pArray);
     this->getAttributes(pArray->pAttributeList);
     doCallbacksGenericPointer(pArray, NDArrayData, 0);
 }

--- a/NDDriverStdArraysApp/src/NDDriverStdArrays.cpp
+++ b/NDDriverStdArraysApp/src/NDDriverStdArrays.cpp
@@ -310,7 +310,6 @@ void NDDriverStdArrays::setArrayComplete()
 void NDDriverStdArrays::doCallbacks()
 {
     NDArray *pArray = this->pArrays[0];
-    epicsTimeStamp startTime;
     int imageCounter;
 
     if (!pArray) return;
@@ -321,9 +320,8 @@ void NDDriverStdArrays::doCallbacks()
 
     /* Put the frame number and timestamp into the NDArray */
     pArray->uniqueId = imageCounter;
-    epicsTimeGetCurrent(&startTime);
-    pArray->timeStamp = startTime.secPastEpoch+startTime.nsec/1.e9;
     updateTimeStamp(&pArray->epicsTS);
+    pArray->timeStamp = pArray->epicsTS.secPastEpoch + pArray->epicsTS.nsec/1.e9;
     this->getAttributes(pArray->pAttributeList);
     doCallbacksGenericPointer(pArray, NDArrayData, 0);
 }


### PR DESCRIPTION
Part of a series of PRs for AreaDetector repos that sets the outgoing frames' timeStamp member to be equal to the frame's epicsTS member, updated with updateTimeStamp, when not retreiving a timestamp from hardware.